### PR TITLE
Update duna.vim

### DIFF
--- a/colors/duna.vim
+++ b/colors/duna.vim
@@ -11,7 +11,7 @@ highlight clear
 if exists ("syntax_on")
 	syntax reset
 endif
-let g:colors_name="Duna"
+let g:colors_name="duna"
 
 hi ColorColumn term=NONE cterm=NONE ctermbg=236 ctermfg=251 gui=NONE guibg=#303030 guifg=#c6c6c6
 hi Comment term=NONE cterm=NONE ctermbg=NONE ctermfg=58 gui=NONE guibg=NONE guifg=#5f5f00


### PR DESCRIPTION
name has to be changed, otherwise vim starts with an error message:

> Error detected while processing /usr/share/vim/vim74/syntax/synload.vim:
> line   19:
> E185: Cannot find color scheme 'Duna'
> Press ENTER or type command to continue